### PR TITLE
Fix: add display block for mi-label

### DIFF
--- a/label.css
+++ b/label.css
@@ -1,5 +1,6 @@
 .mi-label {
   font-style: normal;
+  display: block;
   font-size: 1rem;
   font-weight: 500;
   color: #1e2025;

--- a/label.scss
+++ b/label.scss
@@ -6,6 +6,7 @@
 
 .mi-label {
     font-style: normal;
+    display: block;
     @include font.size(medium);
     @include font.weight(large);
     @include color.black(base);


### PR DESCRIPTION
Not sure how opinionated the CSS library should be but this fix is for margin to work as expected for mi-label :) 