### PR TITLE
FIX: Remove bottom margin for mi-label

### DIFF
--- a/label.css
+++ b/label.css
@@ -4,7 +4,6 @@
   font-size: 1rem;
   font-weight: 500;
   color: #1e2025;
-  margin-bottom: 16px;
 }
 .mi-label > * {
   margin-top: 4px;

--- a/label.scss
+++ b/label.scss
@@ -10,7 +10,6 @@
     @include font.size(medium);
     @include font.weight(large);
     @include color.black(base);
-    @include margin.bottom(medium);
 
     &>* {
         @include margin.top(xx-small);


### PR DESCRIPTION
I don't think that the label element should have any margin specified as it's not flexible enough.