### PR TITLE
MICMS-1894 - mi-toggle refactoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,17 +668,15 @@
         <div class="row">
             <div class="column">
                 <div class="flex items-center">
-                    <input class="mi-toggle" id="toggle-1" type="checkbox" />
-                    <label class="mi-toggle-btn" for="toggle-1"></label>
+                    <input type="checkbox" id="toggle-1" class="mi-toggle" />
                     <label for="toggle-1" class="mi-label">Toggle</label>
                 </div>
             </div>
 
             <div class="column">
                 <div class="flex items-center">
-                    <input class="mi-toggle" id="toggle-2" disabled type="checkbox" />
-                    <label class="mi-toggle-btn" for="toggle-2"></label>
-                    <label class="mi-label">Toggle disabled</label>
+                    <input type="checkbox" id="toggle-2" class="mi-toggle" disabled />
+                    <label for="toggle-2" class="mi-label">Toggle disabled</label>
                 </div>
             </div>
 

--- a/toggle.css
+++ b/toggle.css
@@ -1,47 +1,40 @@
 .mi-toggle {
-  display: none;
-}
-.mi-toggle + .mi-toggle-btn {
-  display: block;
-  position: relative;
-  user-select: none;
-  outline: 0;
-  box-sizing: border-box;
   margin: 0;
+  padding: 2px;
+  box-sizing: border-box;
+  appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
   width: 48px;
   height: 24px;
   border-radius: 9999px;
-  padding: 2px;
-  transition: 300ms ease;
   background-color: #8d98aa;
+  transition: background-color 300ms ease;
 }
-.mi-toggle + .mi-toggle-btn:after, .mi-toggle + .mi-toggle-btn:before {
+.mi-toggle:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+.mi-toggle + .mi-label {
+  margin-left: 8px;
+}
+
+.mi-toggle:checked {
+  background-color: #2a844e;
+}
+
+.mi-toggle::after {
+  content: "";
+  display: inline-block;
   width: 20px;
   height: 20px;
-  content: "";
-  position: relative;
-  display: block;
-}
-.mi-toggle + .mi-toggle-btn:after {
-  left: 0;
+  transform: translateX(0px);
   border-radius: 50%;
   background-color: #fcfcfc;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.125), 0 2px 2px rgba(0, 0, 0, 0.125);
   transition: 300ms ease;
 }
-.mi-toggle + .mi-toggle-btn:before {
-  display: none;
-}
-.mi-toggle + .mi-toggle-btn + .mi-label {
-  margin: 0 0 0 8px;
-}
-.mi-toggle:checked + .mi-toggle-btn {
-  background-color: #2a844e;
-}
-.mi-toggle:checked + .mi-toggle-btn:after {
-  left: 24px;
-}
-.mi-toggle:disabled + .mi-toggle-btn {
-  opacity: 0.48;
-  cursor: not-allowed;
+
+.mi-toggle:checked::after {
+  transform: translateX(24px);
 }

--- a/toggle.css
+++ b/toggle.css
@@ -1,40 +1,47 @@
 .mi-toggle {
   margin: 0;
-  padding: 2px;
-  box-sizing: border-box;
-  appearance: none;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  width: 48px;
-  height: 24px;
-  border-radius: 9999px;
-  background-color: #8d98aa;
-  transition: background-color 300ms ease;
 }
 .mi-toggle:disabled {
-  opacity: 0.48;
   cursor: not-allowed;
 }
 .mi-toggle + .mi-label {
   margin-left: 8px;
 }
 
-.mi-toggle:checked {
-  background-color: #2a844e;
-}
+@supports (appearance: none) or (-moz-appearance: none) or (-webkit-appearance: none) {
+  .mi-toggle {
+    padding: 2px;
+    box-sizing: border-box;
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    width: 48px;
+    height: 24px;
+    border-radius: 9999px;
+    background-color: #8d98aa;
+    transition: background-color 300ms ease;
+  }
+  .mi-toggle:disabled {
+    opacity: 0.48;
+  }
 
-.mi-toggle::after {
-  content: "";
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  transform: translateX(0px);
-  border-radius: 50%;
-  background-color: #fcfcfc;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.125), 0 2px 2px rgba(0, 0, 0, 0.125);
-  transition: 300ms ease;
-}
+  .mi-toggle:checked {
+    background-color: #2a844e;
+  }
 
-.mi-toggle:checked::after {
-  transform: translateX(24px);
+  .mi-toggle::after {
+    content: "";
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    transform: translateX(0px);
+    border-radius: 50%;
+    background-color: #fcfcfc;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.125), 0 2px 2px rgba(0, 0, 0, 0.125);
+    transition: 300ms ease;
+  }
+
+  .mi-toggle:checked::after {
+    transform: translateX(24px);
+  }
 }

--- a/toggle.scss
+++ b/toggle.scss
@@ -1,64 +1,51 @@
+@use 'node_modules/@mapsindoors/midt/margin';
 @use 'node_modules/@mapsindoors/midt/border';
-@use 'node_modules/@mapsindoors/midt/padding';
 @use 'node_modules/@mapsindoors/midt/opacity';
 @use 'node_modules/@mapsindoors/midt/sizing';
 @use "node_modules/@mapsindoors/midt/background-color";
 @use "node_modules/@mapsindoors/midt/elevation";
 @use "node_modules/@mapsindoors/midt/transitions";
+@use "node_modules/@mapsindoors/midt/build/scss/variables";
 
 .mi-toggle {
-    display: none;
+    margin: 0;
+    padding: 2px;
+    box-sizing: border-box;
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    @include sizing.width(xxx-large);
+    @include sizing.height(large);
+    @include border.radius(pill);
+    @include background-color.gray(60);
+    transition: background-color variables.$transition-quickly;
 
-    +.mi-toggle-btn {
-        display: block;
-        position: relative;
-        user-select: none;
-        outline: 0;
-        box-sizing: border-box;
-        margin: 0;
-        @include sizing.width(xxx-large);
-        @include sizing.height(large);
-        @include border.radius(pill);
-        @include padding.all(xxx-small);
-        @include transitions.transition(quickly);
-        @include background-color.gray(60);
-
-        &:after,
-        &:before {
-            width: 20px;
-            height: 20px;
-            content: "";
-            position: relative;
-            display: block;
-        }
-
-        &:after {
-            left: 0;
-            @include border.radius(circle);
-            @include background-color.white(base);
-            @include elevation.elevation(x-small);
-            @include transitions.transition(quickly);
-        }
-
-        &:before {
-            display: none;
-        }
-
-        +.mi-label {
-            margin: 0 0 0 8px;
-        }
-    }
-
-    &:checked+.mi-toggle-btn {
-        @include background-color.green(60);
-
-        &:after {
-            left: 24px;
-        }
-    }
-
-    &:disabled+.mi-toggle-btn {
+    &:disabled {
         @include opacity.opacity(large);
         cursor: not-allowed;
     }
+
+    +.mi-label {
+        @include margin.left(x-small)
+    }
+}
+
+.mi-toggle:checked {
+    @include background-color.green(60);
+}
+
+.mi-toggle::after {
+    content: "";
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    transform: translateX(0px);
+    @include border.radius(circle);
+    @include background-color.white(base);
+    @include elevation.elevation(x-small);
+    @include transitions.transition(quickly);
+}
+
+.mi-toggle:checked::after {
+    transform: translateX(24px);
 }

--- a/toggle.scss
+++ b/toggle.scss
@@ -7,45 +7,54 @@
 @use "node_modules/@mapsindoors/midt/transitions";
 @use "node_modules/@mapsindoors/midt/build/scss/variables";
 
+
 .mi-toggle {
     margin: 0;
-    padding: 2px;
-    box-sizing: border-box;
-    appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    @include sizing.width(xxx-large);
-    @include sizing.height(large);
-    @include border.radius(pill);
-    @include background-color.gray(60);
-    transition: background-color variables.$transition-quickly;
 
     &:disabled {
-        @include opacity.opacity(large);
         cursor: not-allowed;
     }
 
     +.mi-label {
-        @include margin.left(x-small)
+        @include margin.left(x-small);
     }
 }
 
-.mi-toggle:checked {
-    @include background-color.green(60);
-}
+@supports (appearance: none) or (-moz-appearance: none) or (-webkit-appearance: none) {
+    .mi-toggle {
+        padding: 2px;
+        box-sizing: border-box;
+        appearance: none;
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        @include sizing.width(xxx-large);
+        @include sizing.height(large);
+        @include border.radius(pill);
+        @include background-color.gray(60);
+        transition: background-color variables.$transition-quickly;
 
-.mi-toggle::after {
-    content: "";
-    display: inline-block;
-    width: 20px;
-    height: 20px;
-    transform: translateX(0px);
-    @include border.radius(circle);
-    @include background-color.white(base);
-    @include elevation.elevation(x-small);
-    @include transitions.transition(quickly);
-}
+        &:disabled {
+            @include opacity.opacity(large);
+        }
+    }
 
-.mi-toggle:checked::after {
-    transform: translateX(24px);
+    .mi-toggle:checked {
+        @include background-color.green(60);
+    }
+
+    .mi-toggle::after {
+        content: "";
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        transform: translateX(0px);
+        @include border.radius(circle);
+        @include background-color.white(base);
+        @include elevation.elevation(x-small);
+        @include transitions.transition(quickly);
+    }
+
+    .mi-toggle:checked::after {
+        transform: translateX(24px);
+    }
 }


### PR DESCRIPTION
**What**
* Refactoring of mi-toggle to get native focus working

**Why**
* Today the toggle can't be focused

**How**
* Refactored the code so the styling is applied to the input itself. This also means that the "mi-toggle-btn" label element isn't needed anymore and that IE isn't supported anymore.